### PR TITLE
_date = ... breaks KVO and there is no other way to know if date has changed.

### DIFF
--- a/SRMonthPicker.m
+++ b/SRMonthPicker.m
@@ -165,7 +165,9 @@
     NSDateComponents* components = [[NSDateComponents alloc] init];
     components.month = 1 + ([self selectedRowInComponent:self.monthComponent] % self.monthStrings.count);
     components.year = [self yearFromRow:[self selectedRowInComponent:self.yearComponent]];
+    [self willChangeValueForKey:@"date"];
     _date = [[NSCalendar currentCalendar] dateFromComponents:components];
+    [self didChangeValueForKey:@"date"];
 }
 
 -(NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView


### PR DESCRIPTION
_date = ... breaks KVO and there is no other way to know if date has changed as SRMonthPicker overwrites delegate.
