### PR TITLE
Option for years only, nominative months, added locale, updated default font

### DIFF
--- a/Pod/Classes/SRMonthPicker.h
+++ b/Pod/Classes/SRMonthPicker.h
@@ -23,7 +23,7 @@
 #import <UIKit/UIKit.h>
 
 #ifndef IBInspectable
-	#define IBInspectable
+    #define IBInspectable
 #endif
 
 @class SRMonthPicker;

--- a/Pod/Classes/SRMonthPicker.h
+++ b/Pod/Classes/SRMonthPicker.h
@@ -1,16 +1,16 @@
 /*
  Copyright (C) 2012-2015 Simon Rice
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,65 +23,68 @@
 #import <UIKit/UIKit.h>
 
 #ifndef IBInspectable
-    #define IBInspectable
+	#define IBInspectable
 #endif
 
 @class SRMonthPicker;
 
 /**
-  Defines a set of optional methods you can use to receive change-related 
-  messages for SRMonthPicker objects.  All of the methods in this protocol are 
-  optional.  Typically, the delegate implements other optional methods to 
-  respond to new selections. 
+ Defines a set of optional methods you can use to receive change-related
+ messages for SRMonthPicker objects.  All of the methods in this protocol are
+ optional.  Typically, the delegate implements other optional methods to
+ respond to new selections.
  */
 @protocol SRMonthPickerDelegate <NSObject>
 
 @optional
 
 /**
-  Tells the delegate that a specified date is about to be selected.
-  @param monthPicker A month picker object informing the delegate about the 
-  impending selection.
-*/
+ Tells the delegate that a specified date is about to be selected.
+ @param monthPicker A month picker object informing the delegate about the
+ impending selection.
+ */
 - (void)monthPickerWillChangeDate:(SRMonthPicker *)monthPicker;
 /**
-  Tells the delegate that a specified date has been selected.
-  @param monthPicker A month picker object informing the delegate about the 
-  committed selection.
-*/
+ Tells the delegate that a specified date has been selected.
+ @param monthPicker A month picker object informing the delegate about the
+ committed selection.
+ */
 - (void)monthPickerDidChangeDate:(SRMonthPicker *)monthPicker;
 
 @end
 
 /**
-  The SRMonthPicker class implements an object that uses multiple rotating 
-  wheels to allow users to select a month and year.  This is similar to both 
-  iOS's UIDatePicker set to Date-only mode without the day element and Mobile
-  Safari's picker view that appears for an `<input type="month" />` tag.
+ The SRMonthPicker class implements an object that uses multiple rotating
+ wheels to allow users to select a month and year.  This is similar to both
+ iOS's UIDatePicker set to Date-only mode without the day element and Mobile
+ Safari's picker view that appears for an `<input type="month" />` tag.
 
-  Unlike UIDatePicker, SRMonthPicker does inherit from UIPickerView.  It does 
-  use both UIPickerViewDataSource and UIPickerViewDelegate, but presents a 
-  monthPickerDelegate property.
-*/
+ Unlike UIDatePicker, SRMonthPicker does inherit from UIPickerView.  It does
+ use both UIPickerViewDataSource and UIPickerViewDelegate, but presents a
+ monthPickerDelegate property.
+ */
 @interface SRMonthPicker : UIPickerView<UIPickerViewDataSource, UIPickerViewDelegate>
 
 /**
-  The designated delegate for the month picker.
-  @warning **Important:** The delegate property is already used internally for 
-  UIPickerView's delegate - **please don't read from or assign to it**!
-  */
+ The designated delegate for the month picker.
+ @warning **Important:** The delegate property is already used internally for
+ UIPickerView's delegate - **please don't read from or assign to it**!
+ */
 @property (nonatomic, weak) id<SRMonthPickerDelegate> monthPickerDelegate;
 
 /**
-  The date represented by the month picker.
-  
-  The day component is ignored when written, and set to 1 when read.
-  */
-@property (nonatomic, strong) IBInspectable NSDate* date;
+ The date represented by the month picker.
+
+ The day component is ignored when written, and set to 1 when read.
+ */
+@property (nonatomic, strong) IBInspectable NSDate *date;
 
 /// The calendar currently being used
 @property (nonatomic, strong, readonly) NSCalendar *calendar;
-  
+
+/// The locale currently being used
+@property (nonatomic, strong, readonly) NSLocale *locale;
+
 /// The minimum year that a month picker can show.
 @property (nonatomic) IBInspectable NSInteger minimumYear;
 
@@ -109,20 +112,23 @@
 /// en-US alias for `fontColour`.
 @property (nonatomic, strong, getter = fontColour, setter = setFontColour:) IBInspectable UIColor *fontColor;
 
-/**
-  Designated initialiser.
+/// Use only years
+@property (nonatomic) IBInspectable BOOL onlyYear;
 
-  Initializes and returns a newly allocated month picker with the current calendar, 
-  month & year.
-*/
+/**
+ Designated initialiser.
+
+ Initializes and returns a newly allocated month picker with the current calendar,
+ month & year.
+ */
 -(id)init;
 
 /**
-  Initializes and returns a newly allocated month picker with the specified 
-  date and current calendar.
-  @param date The date to be represented by the month picker -  the day 
-  component will be ignored.
-*/
+ Initializes and returns a newly allocated month picker with the specified
+ date and current calendar.
+ @param date The date to be represented by the month picker -  the day
+ component will be ignored.
+ */
 -(id)initWithDate:(NSDate *)date;
 
 /**
@@ -132,6 +138,6 @@
  component will be ignored.
  @param calendar The calendar to used by the date.
  */
--(id)initWithDate:(NSDate *)date calendar:(NSCalendar *)calendar;
+-(id)initWithDate:(NSDate *)date calendar:(NSCalendar *)calendar locale:(NSLocale *)locale;
 
 @end

--- a/Pod/Classes/SRMonthPicker.m
+++ b/Pod/Classes/SRMonthPicker.m
@@ -1,16 +1,16 @@
 /*
  Copyright (C) 2012-2015 Simon Rice
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,20 +23,20 @@
 #import "SRMonthPicker.h"
 
 #ifdef NSCalendarUnitMonth
-#define NSCalendarUnitMonth NSMonthCalendarUnit
+	#define NSCalendarUnitMonth NSMonthCalendarUnit
 #endif
 
 #ifdef NSCalendarUnitYear
-#define NSCalendarUnitYear NSYearCalendarUnit
+	#define NSCalendarUnitYear NSYearCalendarUnit
 #endif
 
 @interface SRMonthPicker()
 
 @property (nonatomic) NSInteger monthComponent;
 @property (nonatomic) NSInteger yearComponent;
-@property (nonatomic, strong, readonly) NSArray* monthStrings;
-@property (nonatomic, strong, readonly) NSDateFormatter* monthFormatter;
-@property (nonatomic, strong, readonly) NSDateFormatter* yearFormatter;
+@property (nonatomic, strong, readonly) NSArray *monthStrings;
+@property (nonatomic, strong, readonly) NSDateFormatter *monthFormatter;
+@property (nonatomic, strong, readonly) NSDateFormatter *yearFormatter;
 
 -(void)p_prepare;
 -(NSInteger)p_yearFromRow:(NSUInteger)row;
@@ -51,314 +51,345 @@ static const NSInteger SRDefaultMinimumYear = 1;
 static const NSInteger SRDefaultMaximumYear = 99999;
 static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalendarUnitYear;
 
-- (id)initWithDate:(NSDate *)date calendar:(NSCalendar *)calendar
+- (id)initWithDate:(NSDate *)date calendar:(NSCalendar *)calendar locale:(NSLocale *)locale
 {
-    self = [super init];
-    
-    if (self)
-    {
-        _calendar = calendar;
-        [self p_prepare];
-        [self setDate:date];
-        self.showsSelectionIndicator = YES;
-    }
-    
-    return self;
+	self = [super init];
+
+	if (self)
+	{
+		_calendar = calendar;
+		_locale = locale;
+		[self p_prepare];
+		[self setDate:date];
+		self.showsSelectionIndicator = YES;
+	}
+
+	return self;
 }
 
 -(id)initWithDate:(NSDate *)date
 {
-    self = [self initWithDate:date calendar:[NSCalendar currentCalendar]];
-    return self;
+	self = [self initWithDate:date calendar:[NSCalendar currentCalendar] locale:[NSLocale currentLocale]];
+	return self;
 }
 
 -(id)init
 {
-    self = [self initWithDate:[NSDate date] calendar:[NSCalendar currentCalendar]];
-    return self;
+	self = [self initWithDate:[NSDate date] calendar:[NSCalendar currentCalendar] locale:[NSLocale currentLocale]];
+	return self;
 }
 
 -(id)initWithCoder:(NSCoder *)aDecoder
 {
-    self = [super initWithCoder:aDecoder];
-    
-    if (self)
-    {
-        _minimumYear = SRDefaultMinimumYear;
-        _maximumYear = SRDefaultMaximumYear;
-        [self p_prepare];
-        if (!_calendar)
-            _calendar = [NSCalendar currentCalendar];
-        if (!_date)
-            [self setDate:[NSDate date]];
-    }
-    
-    return self;
+	self = [super initWithCoder:aDecoder];
+
+	if (self)
+	{
+		_minimumYear = SRDefaultMinimumYear;
+		_maximumYear = SRDefaultMaximumYear;
+		[self p_prepare];
+		if (!_calendar)
+			_calendar = [NSCalendar currentCalendar];
+		if (!_locale) {
+			_locale = [NSLocale currentLocale];
+		}
+		if (!_date)
+			[self setDate:[NSDate date]];
+	}
+
+	return self;
 }
 
 -(id)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:frame];
-    
-    if (self)
-    {
-        _minimumYear = SRDefaultMinimumYear;
-        _maximumYear = SRDefaultMaximumYear;
-        
-        [self p_prepare];
-        if (!_calendar)
-            _calendar = [NSCalendar currentCalendar];
-        if (!_date)
-            [self setDate:[NSDate date]];
-    }
-    
-    return self;
+	self = [super initWithFrame:frame];
+
+	if (self)
+	{
+		_minimumYear = SRDefaultMinimumYear;
+		_maximumYear = SRDefaultMaximumYear;
+
+		[self p_prepare];
+		if (!_calendar)
+			_calendar = [NSCalendar currentCalendar];
+		if (!_locale) {
+			_locale = [NSLocale currentLocale];
+		}
+		if (!_date)
+			[self setDate:[NSDate date]];
+	}
+
+	return self;
 }
 
 -(id<UIPickerViewDelegate>)delegate
 {
-    return self;
+	return self;
 }
 
 -(void)setDelegate:(id<UIPickerViewDelegate>)delegate
 {
-    if ([delegate isEqual:self])
-        [super setDelegate:delegate];
+	if ([delegate isEqual:self])
+		[super setDelegate:delegate];
 }
 
 -(id<UIPickerViewDataSource>)dataSource
 {
-    return self;
+	return self;
 }
 
 -(void)setDataSource:(id<UIPickerViewDataSource>)dataSource
 {
-    if ([dataSource isEqual:self])
-        [super setDataSource:dataSource];
+	if ([dataSource isEqual:self])
+		[super setDataSource:dataSource];
 }
 
 -(NSInteger)monthComponent
 {
-    return self.yearComponent ^ 1;
+	return self.yearComponent ^ 1;
 }
 
 -(NSInteger)yearComponent
 {
-    return !self.yearFirst;
+	if (self.onlyYear) {
+		return 0;
+	}
+
+	return !self.yearFirst;
 }
 
 -(NSDateFormatter *)monthFormatter {
-    static NSDateFormatter *formatter;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        formatter = [[NSDateFormatter alloc] init];
-        formatter.calendar = self.calendar;
-        formatter.dateFormat = @"MMMM";
-    });
-    return formatter;
+	static NSDateFormatter *formatter;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		formatter = [[NSDateFormatter alloc] init];
+		formatter.calendar = self.calendar;
+		formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"MMMM" options:0 locale:self.locale];
+	});
+	return formatter;
 }
 
 -(NSDateFormatter *)yearFormatter {
-    static NSDateFormatter *formatter;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        formatter = [[NSDateFormatter alloc] init];
-        formatter.calendar = self.calendar;
-        formatter.dateFormat = @"y";
-    });
-    return formatter;
+	static NSDateFormatter *formatter;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		formatter = [[NSDateFormatter alloc] init];
+		formatter.calendar = self.calendar;
+		formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"y" options:0 locale:self.locale];
+	});
+	return formatter;
 }
 
 -(NSArray *)monthStrings
 {
-    return self.monthFormatter.monthSymbols;
+	if (self.onlyYear) {
+		return @[];
+	}
+
+	return self.monthFormatter.standaloneMonthSymbols;
 }
 
 -(void)setYearFirst:(BOOL)yearFirst
 {
-    _yearFirst = yearFirst;
-    NSDate* date = self.date;
-    [self reloadAllComponents];
-    [self setNeedsLayout];
-    [self setDate:date];
+	_yearFirst = yearFirst;
+	NSDate *date = self.date;
+	[self reloadAllComponents];
+	[self setNeedsLayout];
+	[self setDate:date];
 }
 
 -(void)setMinimumYear:(NSInteger)minimumYear
 {
-    NSDate* currentDate = self.date;
-    NSDateComponents* components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
-    components.timeZone = [NSTimeZone defaultTimeZone];
-    
-    if (components.year < minimumYear)
-        components.year = minimumYear;
-    
-    _minimumYear = minimumYear;
-    [self reloadAllComponents];
-    [self setDate:[self.calendar dateFromComponents:components]];
+	NSDate *currentDate = self.date;
+	NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
+	components.timeZone = [NSTimeZone defaultTimeZone];
+
+	if (components.year < minimumYear)
+		components.year = minimumYear;
+
+	_minimumYear = minimumYear;
+	[self reloadAllComponents];
+	[self setDate:[self.calendar dateFromComponents:components]];
 }
 
 -(void)setMaximumYear:(NSInteger)maximumYear
 {
-    NSDate* currentDate = self.date;
-    NSDateComponents* components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
-    components.timeZone = [NSTimeZone defaultTimeZone];
-    
-    if (components.year > maximumYear)
-        components.year = maximumYear;
-    
-    _maximumYear = maximumYear;
-    [self reloadAllComponents];
-    [self setDate:[self.calendar dateFromComponents:components]];
+	NSDate *currentDate = self.date;
+	NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
+	components.timeZone = [NSTimeZone defaultTimeZone];
+
+	if (components.year > maximumYear)
+		components.year = maximumYear;
+
+	_maximumYear = maximumYear;
+	[self reloadAllComponents];
+	[self setDate:[self.calendar dateFromComponents:components]];
 }
 
 -(void)setWrapMonths:(BOOL)wrapMonths
 {
-    _wrapMonths = wrapMonths;
-    [self reloadAllComponents];
+	_wrapMonths = wrapMonths;
+	[self reloadAllComponents];
 }
 
 -(void)setDate:(NSDate *)date
 {
-    NSDateComponents* components = [self.calendar components:SRDateComponentFlags fromDate:date];
-    components.timeZone = [NSTimeZone defaultTimeZone];
-    
-    if (self.minimumYear && components.year < self.minimumYear)
-        components.year = self.minimumYear;
-    else if (self.maximumYear && components.year > self.maximumYear)
-        components.year = self.maximumYear;
-    
-    if(self.wrapMonths) {
-        NSInteger monthMidpoint = self.monthStrings.count * (SRMonthRowMultiplier / 2);
-        
-        [self selectRow:(components.month - 1 + monthMidpoint) inComponent:self.monthComponent animated:NO];
-    } else
-        [self selectRow:(components.month - 1) inComponent:self.monthComponent animated:NO];
-        
-    [self selectRow:[self p_rowFromYear:components.year] inComponent:self.yearComponent animated:NO];
-    
-    _date = [self.calendar dateFromComponents:components];
+	NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:date];
+	components.timeZone = [NSTimeZone defaultTimeZone];
+
+	if (self.minimumYear && components.year < self.minimumYear)
+		components.year = self.minimumYear;
+	else if (self.maximumYear && components.year > self.maximumYear)
+		components.year = self.maximumYear;
+
+	if (!self.onlyYear) {
+		if(self.wrapMonths) {
+			NSInteger monthMidpoint = self.monthStrings.count * (SRMonthRowMultiplier / 2);
+
+			[self selectRow:(components.month - 1 + monthMidpoint) inComponent:self.monthComponent animated:NO];
+		} else
+			[self selectRow:(components.month - 1) inComponent:self.monthComponent animated:NO];
+	}
+
+	[self selectRow:[self p_rowFromYear:components.year] inComponent:self.yearComponent animated:NO];
+
+	_date = [self.calendar dateFromComponents:components];
+}
+
+- (void)setOnlyYear:(BOOL)onlyYear
+{
+	_onlyYear = onlyYear;
+
+	NSDate *date = self.date;
+	[self reloadAllComponents];
+	[self setNeedsLayout];
+	[self setDate:date];
 }
 
 -(void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
-    NSDateComponents* components = [[NSDateComponents alloc] init];
-    components.month = 1 + ([self selectedRowInComponent:self.monthComponent] % self.monthStrings.count);
-    components.year = [self p_yearFromRow:[self selectedRowInComponent:self.yearComponent]];
-    
-    [self willChangeValueForKey:@"date"];
-    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerWillChangeDate:)])
-        [self.monthPickerDelegate monthPickerWillChangeDate:self];
-    
-    _date = [self.calendar dateFromComponents:components];
-    
-    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerDidChangeDate:)])
-        [self.monthPickerDelegate monthPickerDidChangeDate:self];
-    [self didChangeValueForKey:@"date"];
+	NSDateComponents *components = [[NSDateComponents alloc] init];
+	components.month = self.onlyYear ? 1 : (1 + ([self selectedRowInComponent:self.monthComponent] % self.monthStrings.count));
+	components.year = [self p_yearFromRow:[self selectedRowInComponent:self.yearComponent]];
+
+	[self willChangeValueForKey:@"date"];
+	if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerWillChangeDate:)])
+		[self.monthPickerDelegate monthPickerWillChangeDate:self];
+
+	_date = [self.calendar dateFromComponents:components];
+
+	if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerDidChangeDate:)])
+		[self.monthPickerDelegate monthPickerDidChangeDate:self];
+	[self didChangeValueForKey:@"date"];
 }
 
 -(NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView
 {
-    return 2;
+	if (self.onlyYear) {
+		return 1;
+	}
+
+	return 2;
 }
 
 -(NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
 {
-    if (component == self.monthComponent && !self.wrapMonths)
-        return self.monthStrings.count;
-    else if(component == self.monthComponent)
-        return SRMonthRowMultiplier * self.monthStrings.count;
-    
-    NSInteger maxYear = SRDefaultMaximumYear;
-    if (self.maximumYear)
-        maxYear = self.maximumYear;
-    
-    return [self p_rowFromYear:maxYear] + 1;
+	if (component == self.monthComponent && !self.wrapMonths)
+		return self.monthStrings.count;
+	else if(component == self.monthComponent)
+		return SRMonthRowMultiplier * self.monthStrings.count;
+
+	NSInteger maxYear = SRDefaultMaximumYear;
+	if (self.maximumYear)
+		maxYear = self.maximumYear;
+
+	return [self p_rowFromYear:maxYear] + 1;
 }
 
 -(CGFloat)pickerView:(UIPickerView *)pickerView widthForComponent:(NSInteger)component
 {
-    if (component == self.monthComponent)
-        return 150.0f;
-    else
-        return 76.0f;
+	if (component == self.monthComponent)
+		return 160.0f;
+	else
+		return 80.0f;
 }
 
 -(UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row forComponent:(NSInteger)component reusingView:(UIView *)view
 {
-    CGFloat width = [self pickerView:self widthForComponent:component];
-    CGRect frame = CGRectMake(0.0f, 0.0f, width, 45.0f);
-    
-    if (component == self.monthComponent)
-    {
-        const CGFloat padding = 9.0f;
-        if (component) {
-            frame.origin.x += padding;
-            frame.size.width -= padding;
-        }
-        
-        frame.size.width -= padding;
-    }
-    
-    UILabel* label = [[UILabel alloc] initWithFrame:frame];
-    
-    NSDateFormatter* formatter = nil;
-    
-    if (component == self.monthComponent) {
-        label.text = [self.monthStrings objectAtIndex:(row % self.monthStrings.count)];
-        label.textAlignment = component ? NSTextAlignmentLeft : NSTextAlignmentRight;
-        formatter = self.monthFormatter;
-    } else {
-        formatter = self.yearFormatter;
-        
-        label.text = [NSString stringWithFormat:@"%ld", (long)[self p_yearFromRow:row]];
-        label.textAlignment = NSTextAlignmentCenter;
-    }
-    
-    label.font = self.font;
-    label.textColor = self.fontColour;
-    
-    if (self.enableColourRow && [[formatter stringFromDate:[NSDate date]] isEqualToString:label.text])
-        label.textColor = [UIColor colorWithRed:0.0f green:0.35f blue:0.91f alpha:1.0f];
-    
-    label.backgroundColor = [UIColor clearColor];
-    label.shadowOffset = CGSizeMake(0.0f, 0.1f);
-    label.shadowColor = [UIColor whiteColor];
-    
-    return label;
+	CGFloat width = [self pickerView:self widthForComponent:component];
+	CGRect frame = CGRectMake(0.0f, 0.0f, width, 45.0f);
+
+	if (component == self.monthComponent)
+	{
+		const CGFloat padding = 9.0f;
+		if (component) {
+			frame.origin.x += padding;
+			frame.size.width -= padding;
+		}
+
+		frame.size.width -= padding;
+	}
+
+	UILabel *label = [[UILabel alloc] initWithFrame:frame];
+
+	NSDateFormatter *formatter = nil;
+
+	if (component == self.monthComponent) {
+		label.text = [self.monthStrings objectAtIndex:(row % self.monthStrings.count)];
+		label.textAlignment = component ? NSTextAlignmentLeft : NSTextAlignmentRight;
+		formatter = self.monthFormatter;
+	} else {
+		formatter = self.yearFormatter;
+
+		label.text = [NSString stringWithFormat:@"%ld", (long)[self p_yearFromRow:row]];
+		label.textAlignment = NSTextAlignmentCenter;
+	}
+
+	label.font = self.font;
+	label.textColor = self.fontColour;
+
+	if (self.enableColourRow && [[formatter stringFromDate:[NSDate date]] isEqualToString:label.text])
+		label.textColor = [UIColor colorWithRed:0.0f green:0.35f blue:0.91f alpha:1.0f];
+
+	label.backgroundColor = [UIColor clearColor];
+	label.shadowOffset = CGSizeMake(0.0f, 0.1f);
+	label.shadowColor = [UIColor whiteColor];
+
+	return label;
 }
 
 #pragma mark Private Methods
 
 -(NSInteger)p_yearFromRow:(NSUInteger)row
 {
-    NSInteger minYear = SRDefaultMinimumYear;
-    
-    if (self.minimumYear)
-        minYear = self.minimumYear;
-    
-    return row + minYear;
+	NSInteger minYear = SRDefaultMinimumYear;
+
+	if (self.minimumYear)
+		minYear = self.minimumYear;
+
+	return row + minYear;
 }
 
 -(NSUInteger)p_rowFromYear:(NSInteger)year
 {
-    NSInteger minYear = SRDefaultMinimumYear;
-    
-    if (self.minimumYear)
-        minYear = self.minimumYear;
-    
-    return year - minYear;
+	NSInteger minYear = SRDefaultMinimumYear;
+
+	if (self.minimumYear)
+		minYear = self.minimumYear;
+
+	return year - minYear;
 }
 
 -(void)p_prepare
 {
-    self.dataSource = self;
-    self.delegate = self;
-    
-    self.enableColourRow = YES;
-    self.wrapMonths = YES;
-    
-    self.font = [UIFont boldSystemFontOfSize:24.0f];
-    self.fontColor = [UIColor blackColor];
+	self.dataSource = self;
+	self.delegate = self;
+
+	self.enableColourRow = YES;
+	self.wrapMonths = YES;
+
+	self.font = [UIFont systemFontOfSize:24.0f];
+	self.fontColor = [UIColor blackColor];
 }
 
 @end

--- a/Pod/Classes/SRMonthPicker.m
+++ b/Pod/Classes/SRMonthPicker.m
@@ -23,11 +23,11 @@
 #import "SRMonthPicker.h"
 
 #ifdef NSCalendarUnitMonth
-	#define NSCalendarUnitMonth NSMonthCalendarUnit
+    #define NSCalendarUnitMonth NSMonthCalendarUnit
 #endif
 
 #ifdef NSCalendarUnitYear
-	#define NSCalendarUnitYear NSYearCalendarUnit
+    #define NSCalendarUnitYear NSYearCalendarUnit
 #endif
 
 @interface SRMonthPicker()
@@ -53,343 +53,343 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 
 - (id)initWithDate:(NSDate *)date calendar:(NSCalendar *)calendar locale:(NSLocale *)locale
 {
-	self = [super init];
+    self = [super init];
 
-	if (self)
-	{
-		_calendar = calendar;
-		_locale = locale;
-		[self p_prepare];
-		[self setDate:date];
-		self.showsSelectionIndicator = YES;
-	}
+    if (self)
+    {
+        _calendar = calendar;
+        _locale = locale;
+        [self p_prepare];
+        [self setDate:date];
+        self.showsSelectionIndicator = YES;
+    }
 
-	return self;
+    return self;
 }
 
 -(id)initWithDate:(NSDate *)date
 {
-	self = [self initWithDate:date calendar:[NSCalendar currentCalendar] locale:[NSLocale currentLocale]];
-	return self;
+    self = [self initWithDate:date calendar:[NSCalendar currentCalendar] locale:[NSLocale currentLocale]];
+    return self;
 }
 
 -(id)init
 {
-	self = [self initWithDate:[NSDate date] calendar:[NSCalendar currentCalendar] locale:[NSLocale currentLocale]];
-	return self;
+    self = [self initWithDate:[NSDate date] calendar:[NSCalendar currentCalendar] locale:[NSLocale currentLocale]];
+    return self;
 }
 
 -(id)initWithCoder:(NSCoder *)aDecoder
 {
-	self = [super initWithCoder:aDecoder];
+    self = [super initWithCoder:aDecoder];
 
-	if (self)
-	{
-		_minimumYear = SRDefaultMinimumYear;
-		_maximumYear = SRDefaultMaximumYear;
-		[self p_prepare];
-		if (!_calendar)
-			_calendar = [NSCalendar currentCalendar];
-		if (!_locale) {
-			_locale = [NSLocale currentLocale];
-		}
-		if (!_date)
-			[self setDate:[NSDate date]];
-	}
+    if (self)
+    {
+        _minimumYear = SRDefaultMinimumYear;
+        _maximumYear = SRDefaultMaximumYear;
+        [self p_prepare];
+        if (!_calendar)
+            _calendar = [NSCalendar currentCalendar];
+        if (!_locale) {
+            _locale = [NSLocale currentLocale];
+        }
+        if (!_date)
+            [self setDate:[NSDate date]];
+    }
 
-	return self;
+    return self;
 }
 
 -(id)initWithFrame:(CGRect)frame
 {
-	self = [super initWithFrame:frame];
+    self = [super initWithFrame:frame];
 
-	if (self)
-	{
-		_minimumYear = SRDefaultMinimumYear;
-		_maximumYear = SRDefaultMaximumYear;
+    if (self)
+    {
+        _minimumYear = SRDefaultMinimumYear;
+        _maximumYear = SRDefaultMaximumYear;
 
-		[self p_prepare];
-		if (!_calendar)
-			_calendar = [NSCalendar currentCalendar];
-		if (!_locale) {
-			_locale = [NSLocale currentLocale];
-		}
-		if (!_date)
-			[self setDate:[NSDate date]];
-	}
+        [self p_prepare];
+        if (!_calendar)
+            _calendar = [NSCalendar currentCalendar];
+        if (!_locale) {
+            _locale = [NSLocale currentLocale];
+        }
+        if (!_date)
+            [self setDate:[NSDate date]];
+    }
 
-	return self;
+    return self;
 }
 
 -(id<UIPickerViewDelegate>)delegate
 {
-	return self;
+    return self;
 }
 
 -(void)setDelegate:(id<UIPickerViewDelegate>)delegate
 {
-	if ([delegate isEqual:self])
-		[super setDelegate:delegate];
+    if ([delegate isEqual:self])
+        [super setDelegate:delegate];
 }
 
 -(id<UIPickerViewDataSource>)dataSource
 {
-	return self;
+    return self;
 }
 
 -(void)setDataSource:(id<UIPickerViewDataSource>)dataSource
 {
-	if ([dataSource isEqual:self])
-		[super setDataSource:dataSource];
+    if ([dataSource isEqual:self])
+        [super setDataSource:dataSource];
 }
 
 -(NSInteger)monthComponent
 {
-	return self.yearComponent ^ 1;
+    return self.yearComponent ^ 1;
 }
 
 -(NSInteger)yearComponent
 {
-	if (self.onlyYear) {
-		return 0;
-	}
+    if (self.onlyYear) {
+        return 0;
+    }
 
-	return !self.yearFirst;
+    return !self.yearFirst;
 }
 
 -(NSDateFormatter *)monthFormatter {
-	static NSDateFormatter *formatter;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		formatter = [[NSDateFormatter alloc] init];
-		formatter.calendar = self.calendar;
-		formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"MMMM" options:0 locale:self.locale];
-	});
-	return formatter;
+    static NSDateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        formatter.calendar = self.calendar;
+        formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"MMMM" options:0 locale:self.locale];
+    });
+    return formatter;
 }
 
 -(NSDateFormatter *)yearFormatter {
-	static NSDateFormatter *formatter;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		formatter = [[NSDateFormatter alloc] init];
-		formatter.calendar = self.calendar;
-		formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"y" options:0 locale:self.locale];
-	});
-	return formatter;
+    static NSDateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        formatter.calendar = self.calendar;
+        formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"y" options:0 locale:self.locale];
+    });
+    return formatter;
 }
 
 -(NSArray *)monthStrings
 {
-	if (self.onlyYear) {
-		return @[];
-	}
+    if (self.onlyYear) {
+        return @[];
+    }
 
-	return self.monthFormatter.standaloneMonthSymbols;
+    return self.monthFormatter.standaloneMonthSymbols;
 }
 
 -(void)setYearFirst:(BOOL)yearFirst
 {
-	_yearFirst = yearFirst;
-	NSDate *date = self.date;
-	[self reloadAllComponents];
-	[self setNeedsLayout];
-	[self setDate:date];
+    _yearFirst = yearFirst;
+    NSDate *date = self.date;
+    [self reloadAllComponents];
+    [self setNeedsLayout];
+    [self setDate:date];
 }
 
 -(void)setMinimumYear:(NSInteger)minimumYear
 {
-	NSDate *currentDate = self.date;
-	NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
-	components.timeZone = [NSTimeZone defaultTimeZone];
+    NSDate *currentDate = self.date;
+    NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
+    components.timeZone = [NSTimeZone defaultTimeZone];
 
-	if (components.year < minimumYear)
-		components.year = minimumYear;
+    if (components.year < minimumYear)
+        components.year = minimumYear;
 
-	_minimumYear = minimumYear;
-	[self reloadAllComponents];
-	[self setDate:[self.calendar dateFromComponents:components]];
+    _minimumYear = minimumYear;
+    [self reloadAllComponents];
+    [self setDate:[self.calendar dateFromComponents:components]];
 }
 
 -(void)setMaximumYear:(NSInteger)maximumYear
 {
-	NSDate *currentDate = self.date;
-	NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
-	components.timeZone = [NSTimeZone defaultTimeZone];
+    NSDate *currentDate = self.date;
+    NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
+    components.timeZone = [NSTimeZone defaultTimeZone];
 
-	if (components.year > maximumYear)
-		components.year = maximumYear;
+    if (components.year > maximumYear)
+        components.year = maximumYear;
 
-	_maximumYear = maximumYear;
-	[self reloadAllComponents];
-	[self setDate:[self.calendar dateFromComponents:components]];
+    _maximumYear = maximumYear;
+    [self reloadAllComponents];
+    [self setDate:[self.calendar dateFromComponents:components]];
 }
 
 -(void)setWrapMonths:(BOOL)wrapMonths
 {
-	_wrapMonths = wrapMonths;
-	[self reloadAllComponents];
+    _wrapMonths = wrapMonths;
+    [self reloadAllComponents];
 }
 
 -(void)setDate:(NSDate *)date
 {
-	NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:date];
-	components.timeZone = [NSTimeZone defaultTimeZone];
+    NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:date];
+    components.timeZone = [NSTimeZone defaultTimeZone];
 
-	if (self.minimumYear && components.year < self.minimumYear)
-		components.year = self.minimumYear;
-	else if (self.maximumYear && components.year > self.maximumYear)
-		components.year = self.maximumYear;
+    if (self.minimumYear && components.year < self.minimumYear)
+        components.year = self.minimumYear;
+    else if (self.maximumYear && components.year > self.maximumYear)
+        components.year = self.maximumYear;
 
-	if (!self.onlyYear) {
-		if(self.wrapMonths) {
-			NSInteger monthMidpoint = self.monthStrings.count * (SRMonthRowMultiplier / 2);
+    if (!self.onlyYear) {
+        if(self.wrapMonths) {
+            NSInteger monthMidpoint = self.monthStrings.count * (SRMonthRowMultiplier / 2);
 
-			[self selectRow:(components.month - 1 + monthMidpoint) inComponent:self.monthComponent animated:NO];
-		} else
-			[self selectRow:(components.month - 1) inComponent:self.monthComponent animated:NO];
-	}
+            [self selectRow:(components.month - 1 + monthMidpoint) inComponent:self.monthComponent animated:NO];
+        } else
+            [self selectRow:(components.month - 1) inComponent:self.monthComponent animated:NO];
+    }
 
-	[self selectRow:[self p_rowFromYear:components.year] inComponent:self.yearComponent animated:NO];
+    [self selectRow:[self p_rowFromYear:components.year] inComponent:self.yearComponent animated:NO];
 
-	_date = [self.calendar dateFromComponents:components];
+    _date = [self.calendar dateFromComponents:components];
 }
 
 - (void)setOnlyYear:(BOOL)onlyYear
 {
-	_onlyYear = onlyYear;
+    _onlyYear = onlyYear;
 
-	NSDate *date = self.date;
-	[self reloadAllComponents];
-	[self setNeedsLayout];
-	[self setDate:date];
+    NSDate *date = self.date;
+    [self reloadAllComponents];
+    [self setNeedsLayout];
+    [self setDate:date];
 }
 
 -(void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
-	NSDateComponents *components = [[NSDateComponents alloc] init];
-	components.month = self.onlyYear ? 1 : (1 + ([self selectedRowInComponent:self.monthComponent] % self.monthStrings.count));
-	components.year = [self p_yearFromRow:[self selectedRowInComponent:self.yearComponent]];
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.month = self.onlyYear ? 1 : (1 + ([self selectedRowInComponent:self.monthComponent] % self.monthStrings.count));
+    components.year = [self p_yearFromRow:[self selectedRowInComponent:self.yearComponent]];
 
-	[self willChangeValueForKey:@"date"];
-	if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerWillChangeDate:)])
-		[self.monthPickerDelegate monthPickerWillChangeDate:self];
+    [self willChangeValueForKey:@"date"];
+    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerWillChangeDate:)])
+        [self.monthPickerDelegate monthPickerWillChangeDate:self];
 
-	_date = [self.calendar dateFromComponents:components];
+    _date = [self.calendar dateFromComponents:components];
 
-	if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerDidChangeDate:)])
-		[self.monthPickerDelegate monthPickerDidChangeDate:self];
-	[self didChangeValueForKey:@"date"];
+    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerDidChangeDate:)])
+        [self.monthPickerDelegate monthPickerDidChangeDate:self];
+    [self didChangeValueForKey:@"date"];
 }
 
 -(NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView
 {
-	if (self.onlyYear) {
-		return 1;
-	}
+    if (self.onlyYear) {
+        return 1;
+    }
 
-	return 2;
+    return 2;
 }
 
 -(NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
 {
-	if (component == self.monthComponent && !self.wrapMonths)
-		return self.monthStrings.count;
-	else if(component == self.monthComponent)
-		return SRMonthRowMultiplier * self.monthStrings.count;
+    if (component == self.monthComponent && !self.wrapMonths)
+        return self.monthStrings.count;
+    else if(component == self.monthComponent)
+        return SRMonthRowMultiplier * self.monthStrings.count;
 
-	NSInteger maxYear = SRDefaultMaximumYear;
-	if (self.maximumYear)
-		maxYear = self.maximumYear;
+    NSInteger maxYear = SRDefaultMaximumYear;
+    if (self.maximumYear)
+        maxYear = self.maximumYear;
 
-	return [self p_rowFromYear:maxYear] + 1;
+    return [self p_rowFromYear:maxYear] + 1;
 }
 
 -(CGFloat)pickerView:(UIPickerView *)pickerView widthForComponent:(NSInteger)component
 {
-	if (component == self.monthComponent)
-		return 160.0f;
-	else
-		return 80.0f;
+    if (component == self.monthComponent)
+        return 160.0f;
+    else
+        return 80.0f;
 }
 
 -(UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row forComponent:(NSInteger)component reusingView:(UIView *)view
 {
-	CGFloat width = [self pickerView:self widthForComponent:component];
-	CGRect frame = CGRectMake(0.0f, 0.0f, width, 45.0f);
+    CGFloat width = [self pickerView:self widthForComponent:component];
+    CGRect frame = CGRectMake(0.0f, 0.0f, width, 45.0f);
 
-	if (component == self.monthComponent)
-	{
-		const CGFloat padding = 9.0f;
-		if (component) {
-			frame.origin.x += padding;
-			frame.size.width -= padding;
-		}
+    if (component == self.monthComponent)
+    {
+        const CGFloat padding = 9.0f;
+        if (component) {
+            frame.origin.x += padding;
+            frame.size.width -= padding;
+        }
 
-		frame.size.width -= padding;
-	}
+        frame.size.width -= padding;
+    }
 
-	UILabel *label = [[UILabel alloc] initWithFrame:frame];
+    UILabel *label = [[UILabel alloc] initWithFrame:frame];
 
-	NSDateFormatter *formatter = nil;
+    NSDateFormatter *formatter = nil;
 
-	if (component == self.monthComponent) {
-		label.text = [self.monthStrings objectAtIndex:(row % self.monthStrings.count)];
-		label.textAlignment = component ? NSTextAlignmentLeft : NSTextAlignmentRight;
-		formatter = self.monthFormatter;
-	} else {
-		formatter = self.yearFormatter;
+    if (component == self.monthComponent) {
+        label.text = [self.monthStrings objectAtIndex:(row % self.monthStrings.count)];
+        label.textAlignment = component ? NSTextAlignmentLeft : NSTextAlignmentRight;
+        formatter = self.monthFormatter;
+    } else {
+        formatter = self.yearFormatter;
 
-		label.text = [NSString stringWithFormat:@"%ld", (long)[self p_yearFromRow:row]];
-		label.textAlignment = NSTextAlignmentCenter;
-	}
+        label.text = [NSString stringWithFormat:@"%ld", (long)[self p_yearFromRow:row]];
+        label.textAlignment = NSTextAlignmentCenter;
+    }
 
-	label.font = self.font;
-	label.textColor = self.fontColour;
+    label.font = self.font;
+    label.textColor = self.fontColour;
 
-	if (self.enableColourRow && [[formatter stringFromDate:[NSDate date]] isEqualToString:label.text])
-		label.textColor = [UIColor colorWithRed:0.0f green:0.35f blue:0.91f alpha:1.0f];
+    if (self.enableColourRow && [[formatter stringFromDate:[NSDate date]] isEqualToString:label.text])
+        label.textColor = [UIColor colorWithRed:0.0f green:0.35f blue:0.91f alpha:1.0f];
 
-	label.backgroundColor = [UIColor clearColor];
-	label.shadowOffset = CGSizeMake(0.0f, 0.1f);
-	label.shadowColor = [UIColor whiteColor];
+    label.backgroundColor = [UIColor clearColor];
+    label.shadowOffset = CGSizeMake(0.0f, 0.1f);
+    label.shadowColor = [UIColor whiteColor];
 
-	return label;
+    return label;
 }
 
 #pragma mark Private Methods
 
 -(NSInteger)p_yearFromRow:(NSUInteger)row
 {
-	NSInteger minYear = SRDefaultMinimumYear;
+    NSInteger minYear = SRDefaultMinimumYear;
 
-	if (self.minimumYear)
-		minYear = self.minimumYear;
+    if (self.minimumYear)
+        minYear = self.minimumYear;
 
-	return row + minYear;
+    return row + minYear;
 }
 
 -(NSUInteger)p_rowFromYear:(NSInteger)year
 {
-	NSInteger minYear = SRDefaultMinimumYear;
+    NSInteger minYear = SRDefaultMinimumYear;
 
-	if (self.minimumYear)
-		minYear = self.minimumYear;
+    if (self.minimumYear)
+        minYear = self.minimumYear;
 
-	return year - minYear;
+    return year - minYear;
 }
 
 -(void)p_prepare
 {
-	self.dataSource = self;
-	self.delegate = self;
+    self.dataSource = self;
+    self.delegate = self;
 
-	self.enableColourRow = YES;
-	self.wrapMonths = YES;
+    self.enableColourRow = YES;
+    self.wrapMonths = YES;
 
-	self.font = [UIFont systemFontOfSize:24.0f];
-	self.fontColor = [UIColor blackColor];
+    self.font = [UIFont systemFontOfSize:24.0f];
+    self.fontColor = [UIColor blackColor];
 }
 
 @end

--- a/Pod/Classes/SRMonthPicker.m
+++ b/Pod/Classes/SRMonthPicker.m
@@ -55,8 +55,7 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 {
     self = [super init];
 
-    if (self)
-    {
+    if (self) {
         _calendar = calendar;
         _locale = locale;
         [self p_prepare];
@@ -83,18 +82,20 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 {
     self = [super initWithCoder:aDecoder];
 
-    if (self)
-    {
+    if (self) {
         _minimumYear = SRDefaultMinimumYear;
         _maximumYear = SRDefaultMaximumYear;
+
         [self p_prepare];
-        if (!_calendar)
+        if (!_calendar) {
             _calendar = [NSCalendar currentCalendar];
+        }
         if (!_locale) {
             _locale = [NSLocale currentLocale];
         }
-        if (!_date)
+        if (!_date) {
             [self setDate:[NSDate date]];
+        }
     }
 
     return self;
@@ -104,19 +105,20 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 {
     self = [super initWithFrame:frame];
 
-    if (self)
-    {
+    if (self) {
         _minimumYear = SRDefaultMinimumYear;
         _maximumYear = SRDefaultMaximumYear;
 
         [self p_prepare];
-        if (!_calendar)
+        if (!_calendar) {
             _calendar = [NSCalendar currentCalendar];
+        }
         if (!_locale) {
             _locale = [NSLocale currentLocale];
         }
-        if (!_date)
+        if (!_date) {
             [self setDate:[NSDate date]];
+        }
     }
 
     return self;
@@ -129,8 +131,9 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 
 -(void)setDelegate:(id<UIPickerViewDelegate>)delegate
 {
-    if ([delegate isEqual:self])
+    if ([delegate isEqual:self]) {
         [super setDelegate:delegate];
+    }
 }
 
 -(id<UIPickerViewDataSource>)dataSource
@@ -140,8 +143,9 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 
 -(void)setDataSource:(id<UIPickerViewDataSource>)dataSource
 {
-    if ([dataSource isEqual:self])
+    if ([dataSource isEqual:self]) {
         [super setDataSource:dataSource];
+    }
 }
 
 -(NSInteger)monthComponent
@@ -158,25 +162,31 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
     return !self.yearFirst;
 }
 
--(NSDateFormatter *)monthFormatter {
-    static NSDateFormatter *formatter;
+-(NSDateFormatter *)monthFormatter
+{
+    static NSDateFormatter *formatter = nil;
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         formatter = [[NSDateFormatter alloc] init];
         formatter.calendar = self.calendar;
         formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"MMMM" options:0 locale:self.locale];
     });
+
     return formatter;
 }
 
--(NSDateFormatter *)yearFormatter {
-    static NSDateFormatter *formatter;
+-(NSDateFormatter *)yearFormatter
+{
+    static NSDateFormatter *formatter = nil;
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         formatter = [[NSDateFormatter alloc] init];
         formatter.calendar = self.calendar;
         formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:@"y" options:0 locale:self.locale];
     });
+
     return formatter;
 }
 
@@ -204,8 +214,9 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
     NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
     components.timeZone = [NSTimeZone defaultTimeZone];
 
-    if (components.year < minimumYear)
+    if (components.year < minimumYear) {
         components.year = minimumYear;
+    }
 
     _minimumYear = minimumYear;
     [self reloadAllComponents];
@@ -218,8 +229,9 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
     NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:currentDate];
     components.timeZone = [NSTimeZone defaultTimeZone];
 
-    if (components.year > maximumYear)
+    if (components.year > maximumYear) {
         components.year = maximumYear;
+    }
 
     _maximumYear = maximumYear;
     [self reloadAllComponents];
@@ -237,18 +249,22 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
     NSDateComponents *components = [self.calendar components:SRDateComponentFlags fromDate:date];
     components.timeZone = [NSTimeZone defaultTimeZone];
 
-    if (self.minimumYear && components.year < self.minimumYear)
+    if (self.minimumYear && components.year < self.minimumYear) {
         components.year = self.minimumYear;
-    else if (self.maximumYear && components.year > self.maximumYear)
+    }
+    else if (self.maximumYear && components.year > self.maximumYear) {
         components.year = self.maximumYear;
+    }
 
     if (!self.onlyYear) {
         if(self.wrapMonths) {
             NSInteger monthMidpoint = self.monthStrings.count * (SRMonthRowMultiplier / 2);
 
             [self selectRow:(components.month - 1 + monthMidpoint) inComponent:self.monthComponent animated:NO];
-        } else
+        }
+        else {
             [self selectRow:(components.month - 1) inComponent:self.monthComponent animated:NO];
+        }
     }
 
     [self selectRow:[self p_rowFromYear:components.year] inComponent:self.yearComponent animated:NO];
@@ -273,13 +289,15 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
     components.year = [self p_yearFromRow:[self selectedRowInComponent:self.yearComponent]];
 
     [self willChangeValueForKey:@"date"];
-    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerWillChangeDate:)])
+    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerWillChangeDate:)]) {
         [self.monthPickerDelegate monthPickerWillChangeDate:self];
+    }
 
     _date = [self.calendar dateFromComponents:components];
 
-    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerDidChangeDate:)])
+    if ([self.monthPickerDelegate respondsToSelector:@selector(monthPickerDidChangeDate:)]) {
         [self.monthPickerDelegate monthPickerDidChangeDate:self];
+    }
     [self didChangeValueForKey:@"date"];
 }
 
@@ -294,24 +312,29 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 
 -(NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
 {
-    if (component == self.monthComponent && !self.wrapMonths)
+    if (component == self.monthComponent && !self.wrapMonths) {
         return self.monthStrings.count;
-    else if(component == self.monthComponent)
+    }
+    else if(component == self.monthComponent) {
         return SRMonthRowMultiplier * self.monthStrings.count;
+    }
 
     NSInteger maxYear = SRDefaultMaximumYear;
-    if (self.maximumYear)
+    if (self.maximumYear) {
         maxYear = self.maximumYear;
+    }
 
     return [self p_rowFromYear:maxYear] + 1;
 }
 
 -(CGFloat)pickerView:(UIPickerView *)pickerView widthForComponent:(NSInteger)component
 {
-    if (component == self.monthComponent)
+    if (component == self.monthComponent) {
         return 160.0f;
-    else
-        return 80.0f;
+    }
+    else {
+        return 160.0f;
+    }
 }
 
 -(UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row forComponent:(NSInteger)component reusingView:(UIView *)view
@@ -319,8 +342,7 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
     CGFloat width = [self pickerView:self widthForComponent:component];
     CGRect frame = CGRectMake(0.0f, 0.0f, width, 45.0f);
 
-    if (component == self.monthComponent)
-    {
+    if (component == self.monthComponent) {
         const CGFloat padding = 9.0f;
         if (component) {
             frame.origin.x += padding;
@@ -338,7 +360,8 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
         label.text = [self.monthStrings objectAtIndex:(row % self.monthStrings.count)];
         label.textAlignment = component ? NSTextAlignmentLeft : NSTextAlignmentRight;
         formatter = self.monthFormatter;
-    } else {
+    }
+    else {
         formatter = self.yearFormatter;
 
         label.text = [NSString stringWithFormat:@"%ld", (long)[self p_yearFromRow:row]];
@@ -348,8 +371,9 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
     label.font = self.font;
     label.textColor = self.fontColour;
 
-    if (self.enableColourRow && [[formatter stringFromDate:[NSDate date]] isEqualToString:label.text])
+    if (self.enableColourRow && [[formatter stringFromDate:[NSDate date]] isEqualToString:label.text]) {
         label.textColor = [UIColor colorWithRed:0.0f green:0.35f blue:0.91f alpha:1.0f];
+    }
 
     label.backgroundColor = [UIColor clearColor];
     label.shadowOffset = CGSizeMake(0.0f, 0.1f);
@@ -364,8 +388,9 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 {
     NSInteger minYear = SRDefaultMinimumYear;
 
-    if (self.minimumYear)
+    if (self.minimumYear) {
         minYear = self.minimumYear;
+    }
 
     return row + minYear;
 }
@@ -374,8 +399,9 @@ static const NSCalendarUnit SRDateComponentFlags = NSCalendarUnitMonth | NSCalen
 {
     NSInteger minYear = SRDefaultMinimumYear;
 
-    if (self.minimumYear)
+    if (self.minimumYear) {
         minYear = self.minimumYear;
+    }
 
     return year - minYear;
 }


### PR DESCRIPTION
Added ability to use only years, proper names of months (nominative form), added locale property, updated font to new guidelines
It should fix calendar issues as well (https://github.com/simonrice/SRMonthPicker/issues/1, https://github.com/simonrice/SRMonthPicker/issues/2)
